### PR TITLE
Add minimal Flask prototype

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,45 @@
+from flask import Flask, render_template, request, jsonify
+import cv2
+import numpy as np
+import pandas as pd
+import datetime
+
+app = Flask(__name__)
+
+# Simulated function: Detects crowd size and returns estimated headcount
+def get_head_count(frame):
+    gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+    blurred = cv2.GaussianBlur(gray, (5, 5), 0)
+    # Simulated detection logic (replace with actual AI model)
+    people_count = np.random.randint(20, 100)  # Dummy headcount
+    return people_count
+
+# Simulated function: Analyzes energy level based on noise level or movement
+def analyze_vibe(frame):
+    vibe_score = np.random.uniform(0.0, 1.0)
+    if vibe_score > 0.75:
+        return "High energy – switch to party mode."
+    elif vibe_score > 0.4:
+        return "Moderate vibe – keep it flowing."
+    else:
+        return "Low energy – drop a banger."
+
+@app.route('/')
+def home():
+    return render_template('index.html')
+
+@app.route('/analyze', methods=['POST'])
+def analyze():
+    # Simulate receiving a frame (in real app, use camera input)
+    dummy_frame = np.zeros((480, 640, 3), dtype=np.uint8)
+    count = get_head_count(dummy_frame)
+    mood = analyze_vibe(dummy_frame)
+    timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    return jsonify({
+        'headcount': count,
+        'mood': mood,
+        'timestamp': timestamp
+    })
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+opencv-python
+numpy
+pandas

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>VYBINTZ – Nightlife Assistant</title>
+</head>
+<body>
+    <h1>VYBINTZ Nightlife Assistant</h1>
+    <p>Use this app to analyze crowd and vibe.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement a small Flask app that mocks crowd analysis
- add basic requirements list
- provide a minimal HTML page

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6843338edd088328818b7a37af53004a